### PR TITLE
Only run ldconfig when codecs relocated

### DIFF
--- a/eos-relocate-codecs
+++ b/eos-relocate-codecs
@@ -12,9 +12,13 @@ source="/usr/share/EndlessOS/codecs"
 dest="/var/lib/codecs"
 
 # Copy files if they are different or not there yet (but don't delete)
-mkdir -p ${dest} && rsync -av "${source}"/ "${dest}"
+mkdir -p "${dest}"
+changes=$(rsync -ai "${source}"/ "${dest}")
 
 # /var/lib/codecs should be in the search path for ld.so
-ldconfig
+if [ -n "$changes" ]; then
+    echo -e "Changed codecs:\n$changes"
+    ldconfig -X
+fi
 
 exit 0


### PR DESCRIPTION
ldconfig can be very slow, so it should only be run if new codecs were
relocated. The rsync -i|--itemize-changes option can be used to see if
there were any changes when syncing the directories. If the output is
empty, there were not any changes and ldconfig can be skipped.

This also adds -X to the ldconfig call so that it doesn't relink the .so
symlinks and only rebuilds the cache. This slows things down
unnecessarily since we already manage the symlinks for the codecs.

[endlessm/eos-shell#5503]
