### PR TITLE
Don't fail when there are no codecs to relocate

### DIFF
--- a/eos-relocate-codecs
+++ b/eos-relocate-codecs
@@ -11,6 +11,11 @@
 source="/usr/share/EndlessOS/codecs"
 dest="/var/lib/codecs"
 
+if [ ! -d "${source}" ]; then
+    echo "No codecs directory at ${source}, exiting"
+    exit 0
+fi
+
 # Copy files if they are different or not there yet (but don't delete)
 mkdir -p "${dest}"
 changes=$(rsync -ai "${source}"/ "${dest}")


### PR DESCRIPTION
Although the systemd service file doesn't run when the OS codecs
directory doesn't exist, running eos-relocate-codecs will fail if it's
run directly as the image builder does. Be more robust against that
situation and exit early if the directory doesn't exist.

[endlessm/eos-shell#5556]
