### PR TITLE
Fix ConditionNeedsUpdate typo in service file

### DIFF
--- a/eos-relocate-codecs.service.in
+++ b/eos-relocate-codecs.service.in
@@ -10,7 +10,7 @@ DefaultDependencies=no
 Conflicts=shutdown.target
 After=local-fs.target
 Before=sysinit.target shutdown.target systemd-update-done.service
-ConditonNeedsUpdate=/var
+ConditionNeedsUpdate=/var
 
 # Don't run 2 ldconfigs concurrently
 After=ldconfig.service


### PR DESCRIPTION
This was preventing systemd from actually skipping the service when the
/var/.updated file exists.

[endlessm/eos-shell#5592]
