### PR TITLE
Added debian/eos-codecs-manager.install, now that we have a metapackage

### DIFF
--- a/debian/eos-codecs-manager.install
+++ b/debian/eos-codecs-manager.install
@@ -1,0 +1,2 @@
+/lib/systemd/system/eos-relocate-codecs.service
+/usr/bin/eos-relocate-codecs


### PR DESCRIPTION
Otherwise, neither the eos-relocate-codecs script nor the systemd
service file will get installed.

[endlessm/eos-shell#5767]
