### PR TITLE
Replace /usr/share/EndlessOS/codecs with /usr/share/eos-codecs-manager

### DIFF
--- a/eos-relocate-codecs
+++ b/eos-relocate-codecs
@@ -12,7 +12,7 @@ exit_with_error() {
 }
 
 # Directory where the encrypted codec packs should be installed
-source=/usr/share/EndlessOS/codecs
+source=/usr/share/eos-codecs-manager
 if [ ! -d ${source} ]; then
     exit_with_error "No codecs directory at ${source}, exiting"
 fi

--- a/eos-relocate-codecs.service.in
+++ b/eos-relocate-codecs.service.in
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=Helper script to deal with extra codecs
-ConditionPathExists=/usr/share/EndlessOS/codecs
+ConditionPathExists=/usr/share/eos-codecs-manager
 
 # Only run after an update. Needs to be in sysinit.target to run before
 # systemd-update-done.service.


### PR DESCRIPTION
We are trying to get rid of /use/share/EndlessOS, so we need to move
the codecs related stuff out of there.

[endlessm/eos-shell#5921]
