### PR TITLE
Update URL to get our own GStreamer MP3 plugin and include Fluendo's EULA

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,84 @@
+This package will attempt to download an MP3 decoder named libgstflump3dec.so which will be stored in /var/lib/codecs/gstreamer-1.0 on your system. If it exists, the following license applies:
+
+FLUENDO LICENSE AGREEMENT BY FLUENDO, S.A. (“FLUENDO”)
+
+IMPORTANT – READ CAREFULLY THE FOLLOWING LICENSE AGREEMENT AS AMENDED FROM TIME TO TIME AND AVAILABLE AT FLUENDO’S WEBSITE (THE “LICENSE AGREEMENT”), TOGETHER WITH FLUENDO’S SOFTWARE TERMS OF SERVICE, GOVERNS THE DOWNLOADING, INSTALLATION AND/OR USE OF ANY FLUENDO’S PROPRIETARY SOFTWARE, INCLUDING ANY COMPONENTS, COPIES, UPDATES, ENHANCEMENTS, UPGRADES OR SUBSEQUENT VERSIONS THEREOF THAT MAY BE RELEASED BY FLUENDO (COLLECTIVELY, THE “SOFTWARE”) AND ANY ACCOMPANYING MANUALS, HELP FILES AND DOCUMENTATION (THE "DOCUMENTATION"), UNLESS OTHERWISE STATED LOCALLY. PLEASE READ THE TERMS AND CONDITIONS OF THIS LICENSE AGREEMENT AS BY DOWNLOADING, USING AND/OR INSTALLING THE SOFTWARE YOU (THE “LICENSEE”) CONSENT AND AGREE TO BE BOUND BY ALL OF THE TERMS AND CONDITIONS OF THIS LICENSE AGREEMENT. YOU MAY DOWNLOAD, INSTALL AND/OR USE THE SOFTWARE SUBJECT TO THOSE TERMS AND CONDITIONS AND TO ANY APPLICABLE LAW, BEING SOLELY LIABLE FOR ANY BREACH THEREOF. IF YOU DO NOT AGREE TO THIS LICENSE AGREEMENT,FLUENDO DOES NOT GRANT ANY LICENSE TO YOU FOR THE SOFTWARE AND YOU MAY NOT DOWNLOAD, INSTALL OR USE THE SOFTWARE.
+
+BY DOWNLOADING THIS SOFTWARE YOU ALSO CERTIFY UNDER YOUR OWN RESPONSIBILITY THAT YOU ARE OF LEGAL AGE TO ENTER INTO BINDING AGREEMENTS, IN MOST COUNTRIES THIS MEANS THAT YOU ARE AGED 18 OR ABOVE.
+
+THIS LICENSE AGREEMENT SHALL BE APPLICABLE TO THE SOFTWARE CONSIDERED AS A WHOLE AND, IN PARTICULAR BUT WITHOUT LIMITATION, TO ANY FILE INCLUDED THEREIN WHEN FORMING PART OF THIS VERSION, AND TO ANY UPDATE, ENHANCEMENT OR FIX INCORPORATED IN THE PROGRAM.
+
+DEFINITIONS
+
+1. "Final product" means a software or hardware product in a final form of manufacturing intended for distribution to end users and in object code form and that can play back content, including downloaded or streamed content.
+
+2. “Fluendo” means Fluendo SA, whose address is at the end of this document, in person of its at-the-time legal representative.
+
+3. “You” means the individual who downloads the Software or, if the download is on behalf of a legal entity, means the legal entity on behalf of which the software is downloaded, in which case the down loader represents and warrants that he/she has the sufficient powers to act on behalf of the represented party.
+
+GRANT OF LICENSE AND RESTRICTIONS
+
+1. Subject to the Licensee’s acceptance and continued compliance with this License Agreement and with Fluendo’s Software Terms of Service as provided to the Licensee from time to time, Fluendo hereby grants the Licensee a non-exclusive, non-transferable limited license to install, use or otherwise benefit from the functionality of the Software in the manner and for the purposes described in the Documentation, on a per end user basis, as agreed in Fluendo’s Software Terms of Service.
+
+2. Except as expressly authorized by Fluendo in writing, it is forbidden to:
+(i) use this software in other ways than allowed by this contract.
+(ii) tamper or interfere with the functionality, delivery or operation of the Software while using or installing it;
+(iii) sell, resell, rent, lease, distribute, transfer, assign, sub-license or otherwise deal with the Software, its components, the Documentation or any of the rights granted under this License Agreement;
+(iv) duplicate, reproduce or copy (except for reasonable backup purposes) the Software or the Documentation; or
+(v) export or re-export the Software, directly or indirectly, into any country prohibited by law.
+(vi) use this software in the operation of Nuclear facilities, in aircraft navigation, in aircraft communication, in aircraft flight control, in aircraft traffic control systems or in other devices or systems in which serious injury or death to the operator of the device or system, or to others due to a malfunction (including, without limitation, software related delay or failure) could reasonably be foreseen.
+(vii) unless the software is explicitly licensed for the use with such platform(s), use this Final Product on non-PC devices like tablets, pda, portable players and other embedded devices.
+
+3. It is prohibited to modify, remove, suppress, or in any other way make inconspicuous the copyright, digital fingerprints, watermarks, identification labels, legal notices contained within the Software or other technical protection devices or data identifying Fluendo’s or its licensors rights in the Software, its files or its components.
+
+4. No right is granted herein to any third party to use the Software, to the Licensee to use the Software for any third party, or to the Licensee to utilize the Software for any purpose whatsoever not described herein.
+
+OWNERSHIP
+
+5. Save for the right to use the Software and the Documentation expressly provided for in this License Agreement, the Licensee agrees and acknowledges that all title to and rights in the Software, its components, structure, databases, source code or design, and in the Documentation, including without limitation all copyright trademarks, trade secrets, patents, and all other intellectual or industrial property rights and other confidential or proprietary information contained therein remain the property of Fluendo or its licensors.
+
+LIABILITY
+
+6. TO THE MAXIMUM EXTENT PERMITTED BY LAW, AND PROVIDED THAT LIABILITY SHALL NOT BE EXCLUDED OR LIMITED IN RESPECT OF MALICIOUS INTENT OR GROSS NEGLIGENCE, FLUENDO HEREBY EXCLUDES ALL LIABILITY IN RESPECT OF:
+a) ANY LOSS, DAMAGES, CLAIMS OR COSTS WHATSOEVER INCLUDING ANY CONSEQUENTIAL, INDIRECT OR INCIDENTAL DAMAGES, ANY LOST PROFITS OR LOST SAVINGS, ANY DAMAGES RESULTING FROM BUSINESS INTERRUPTION, OR CLAIMS BY A THIRD PARTY, EVEN IF A FLUENDO REPRESENTATIVE HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH LOSS, DAMAGES, CLAIMS OR COSTS.
+b) DAMAGES, CLAIMS OR LIABILITIES ARISING OUT OF ANY OF THE FOLLOWING:
+(i) THE CONTENT (INCLUDING WITHOUT LIMITATION ITS NATURE OR ANY INTELLECTUAL PROPERTY RIGHTS THEREIN) AND/OR ANY OTHER DATA, IMAGES, VIDEOS OR SOUNDS WHATSOEVER THAT THE LICENSEE MAY ACCESS OR TRANSMIT USING THE SOFTWARE;
+(ii) LIABILITY TO ANY EMPLOYER, PRINCIPAL, CLIENT, LESSOR OR PROVIDER OF COMPUTER EQUIPMENT OR FACILITIES, ARISING OUT OF THE INSTALLATION OF OR USE OF THE SOFTWARE;
+(iii) ANY CHARGES WHICH THE LICENSEE MAY INCUR TO ANY TELECOMMUNICATIONS SERVICE OR NETWORK.
+
+7. FLUENDO EXPRESSLY EXCLUDES ALL LIABILITY IN CONNECTION WITH ANY THIRD PARTY APPLICATIONS OR THIRD PARTY COMPONENTS THAT MAY BE INCLUDED WITHIN THE SOFTWARE, OR YOUR USE THEREOF.
+
+8. TO THE MAXIMUM EXTENT PERMITTED BY LAW, FLUENDO’S AGGREGATE LIABILITY AND THAT OF ITS AFFILIATES AND SUPPLIERS UNDER OR IN CONNECTION WITH THIS LICENSE AGREEMENT WILL BE LIMITED IN ANY CASE TO THE AMOUNT PAID FOR THE SOFTWARE, IF ANY, OR, IF HIGHER, TO THE MINIMUM AMOUNT STIPULATED BY A COMPULSORY LAW.
+
+INDEMNITY
+
+9. BY DOWNLOADING, INSTALLING, USING OR UNINSTALLING THE SOFTWARE, THE LICENSEE HEREBY AGREES TO, AT ITS OWN EXPENSE, INDEMNIFY, DEFEND AND HOLD HARMLESS FLUENDO, ITS PARENTS, SUBSIDIARIES AND AFFILIATES, ITS BUSINESS PARTNERS, AND ITS AND THEIR RESPECTIVE DIRECTORS, OFFICERS, EMPLOYEES AND AGENTS FROM AND AGAINST ANY AND ALL LOSSES, DAMAGES, INJURIES, CAUSES OF ACTION, CLAIMS, DEMANDS AND EXPENSES, INCLUDING LEGAL FEES AND EXPENSES, OF WHATEVER KIND OR NATURE ARISING OUT OF, RELATING TO OR RESULTING FROM ANY CLAIM ARISING FROM OR RELATING TO (I) ANY BREACH BY THE LICENSEE OF THIS LICENSE AGREEMENT; OR (II) THE LICENSEE’S DOWNLOAD, INSTALLATION, USE OR UNINSTALLATION OF THE SOFTWARE.
+
+TERMINATION
+
+10. This grant of license begins upon acceptance by the Licensee, either expressly or through use or possession of the Software, and shall continue until terminated as provided in this License Agreement or in Fluendo’s Software Terms of Service.
+
+11. The Licensee may terminate this License Agreement at any time by uninstalling the Software and destroying all copies of the Software. Upon any termination, the Licensee agrees to uninstall the Software and return or destroy all copies of the Software, the Documentation, and all other associated materials.
+
+12. The Licensee’s failure to comply with any of the terms and conditions of this License Agreement or of the Terms of Service terminates the Licensee’s right to use the Software and/or the Documentation, and the Licensee will not receive a refund.
+
+GENERAL
+
+13. This License Agreement contains the entire agreement between the Licensee and Fluendo with respect to the subject matter hereof and supersedes all prior agreements, negotiations, representations of any kind and proposals, written and oral, relating to its subject matter.
+
+14. If any provision of this License Agreement is declared by a court of competent jurisdiction to be invalid, illegal or unenforceable, such provision shall be severed from this License Agreement and the other provisions shall remain in full force and effect.
+
+15. All notices given by either party to the other pursuant to this License Agreement shall be in writing and delivered at its principal place of business by fax or delivery service (in either case with acknowledgement of receipt).
+
+16. The waiver or failure of Fluendo to exercise in any respect any rights provided for in this License Agreement shall not be deemed a waiver of any actual or further right under this License Agreement.
+
+17. The Software could contain, rely upon, depend on, interact with, link to Free and Open Source Software (“FOSS”), Insofar as said FOSS is concerned and where locally specified, the terms of the FOSS license prevail. If You or any third party find any inconsistency, lack of clarity, or any contradiction to the applicable FOSS license, and/or if You or any third party want to exercise your or its rights under it, you or said party is invited to write to:
+FOSS-compliance@fluendo.com.
+
+18. This License Agreement shall be governed by and construed in accordance with the laws of Spain, and the parties submit to the exclusive jurisdiction of the Courts and Tribunals of Barcelona in connection with all matters arising under this License Agreement.
+
+FLUENDO, S.A.
+C.I.F.: A64001217
+Avenida Diagonal 579
+Planta 7.
+08014 Barcelona Spain

--- a/eos-gstreamer-codecs-update
+++ b/eos-gstreamer-codecs-update
@@ -38,10 +38,10 @@ case ${DEB_ARCH} in
     *) gsc_exit_with_error "Unsupported architecture ${DEB_ARCH}" ;;
 esac
 
-REPO_BASE_URL=http://httpredir.debian.org/debian
-PACKAGES_URL=${REPO_BASE_URL}/dists/testing/main/binary-${DEB_ARCH}/Packages.xz
+REPO_BASE_URL=https://d1h291tw0fz159.cloudfront.net/partner
+PACKAGES_URL=${REPO_BASE_URL}/dists/endless/main/binary-${DEB_ARCH}/Packages
 
-FLUENDO_MP3_PKG_NAME=gstreamer1.0-fluendo-mp3
+FLUENDO_MP3_PKG_NAME=oneplay-gstreamer-codecs-mp3
 FLUENDO_MP3_PKG_VERSION=
 FLUENDO_MP3_PKG_SHA1SUM=
 FLUENDO_MP3_PKG_URL=
@@ -53,9 +53,8 @@ gsc_get_field() {
 }
 
 gsc_find_latest_version() {
-    wget "${PACKAGES_URL}" -O "${TEMP_DIR}/Packages.xz" \
+    wget "${PACKAGES_URL}" -O "${TEMP_DIR}/Packages" \
         || gsc_exit_retry_with_error "Failed to download Packages from Debian repository"
-    unxz "${TEMP_DIR}/Packages.xz"
     local package=$(gsc_get_field "Package")
     [ -n "${package}" ] || \
         gsc_exit_with_error "Packages does not contain ${FLUENDO_MP3_PKG_NAME}"


### PR DESCRIPTION
As per an agreement with Fluendo we now host the GStreamer MP3 plugin ourselves,
so we need to update the URL and include Fluendo's EULA in debian/copyright.

https://phabricator.endlessm.com/T10729
