### PR TITLE
correct error from printing freed variant

### DIFF
--- a/src/eos-gst-codec-install.c
+++ b/src/eos-gst-codec-install.c
@@ -242,9 +242,8 @@ eos_gst_report_missing_codec (EosGstCodecInfo *codec_info, EmtrEventRecorder *re
 		g_variant_builder_unref (codec_extra);
 
 		/* Report payload to the metrics server. */
+		g_autofree gchar *payload_str = g_variant_print (payload, FALSE);
 		emtr_event_recorder_record_event_sync (recorder, EOS_CODECS_MANAGER_MISSING_CODEC, payload);
-
-		g_autofree gchar *payload_str = g_variant_print(payload, FALSE);
 		g_message ("eos-gst-codec-install: Reporting to EOS metrics system: %s", payload_str);
 	} else {
 		g_warning ("eos-gst-codec-install: Not enough information to report missing codec!");


### PR DESCRIPTION
Now we're using the _sync method call the GVariant's floating ref is sunk by the event recorder, so payload is free by the time the method returns. This prints it to a string before calling the event recorder so we can still print the debug message _and_ send the metric.
