### PR TITLE
remove old NetworkManager dispatchers on .deb upgrade

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+# remove legacy NetworkManager dispatcher scripts
+if [ "$1" = "configure" ]; then
+  rm -f /etc/NetworkManager/dispatcher.d/50-eos-gstreamer-codecs-update-nm \
+    /etc/NetworkManager/dispatcher.d/50-eos-chromium-codecs-update-nm
+fi
+
+#DEBHELPER#
+


### PR DESCRIPTION
This package used to install some scripts and systemd units which downloaded
codecs from various internet servers. These scripts have been removed but on
systems upgraded with .deb packages, the NetworkManager dispatcher scripts
were handled as configuration files so left in place, causing spurious errors
in journald. This postinst removes those files upon an upgrade.

https://phabricator.endlessm.com/T16035