### PR TITLE
Update libavcodec package name for ffmpeg-3.2.5

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,7 @@ Description: Endless Codecs Manager
 Package: eos-codecs-pack-base
 Architecture: all
 Depends: ${misc:Depends},
-         libavcodec-extra-56,
+         libavcodec-extra57,
          chromium-codecs-ffmpeg-extra
 Conflicts: eos-core
 Description: Endless Codecs Pack (Base)


### PR DESCRIPTION
We are migrating from libav to ffmpeg and the libavcodec package
name has changed.

https://phabricator.endlessm.com/T18766