### PR TITLE
eos-codecs-activate: Do not avoid updates based on file size

### DIFF
--- a/eos-codecs-activate
+++ b/eos-codecs-activate
@@ -115,7 +115,7 @@ handle_codecpack() {
                           --devices \
                           --specials \
                           --itemize-changes \
-                          --size-only ./ ${dest})
+                          ./ ${dest})
     # Clean up.
     popd > /dev/null
     rm -rf ${tmpdir}


### PR DESCRIPTION
We had an issue with old codecs being used although a new update was available.
The problem was that the new update had the exact same size and thus rsync was
skipping the update.

Fix that by not skipping files that match in size only.

https://phabricator.endlessm.com/T29858