### PR TITLE
eos-codecs-pack-base: Remove dep on chromium-codecs-ffmpeg-extra

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -36,8 +36,7 @@ Description: Endless Codecs Manager
 Package: eos-codecs-pack-base
 Architecture: all
 Depends: ${misc:Depends},
-         libavcodec-extra58,
-         chromium-codecs-ffmpeg-extra
+         libavcodec-extra58
 Conflicts: eos-core
 Description: Endless Codecs Pack (Base)
  This metapackage depends on the relevant packages that would be


### PR DESCRIPTION
We are going to direct users to Chromium's Flatpak from flathub and codecs will handled as part of the flatpak (e.g. using extensions).

Note that from what I checked removing this dep should automatically "update" `eos-codecs-activate` to **not** include these codecs.

https://phabricator.endlessm.com/T30997